### PR TITLE
use requirements.txt for python setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Once you have cloned this repo, install the necessary dependencies:
 
 ```bash
 npm i
-pip install --editable .
+python3 -m pip install --force-reinstall -r requirements.txt
 ```
 
 ### Set environment variables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dbt-postgres
+boto3
+pandas


### PR DESCRIPTION
related to https://github.com/NYCPlanning/data-engineering/issues/660

The python packages in `requirements.txt` were chosen because:
- We'll likely use the `dbt` cli and project structure to validate data and run sql queries. 
- We may use `boto3` in python to download files from Digital Ocean spaces (although the `minio` cli might work).