### PR TITLE
load source data for Zoning API DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ export BUILD_ENGINE_URI=${BUILD_ENGINE_SERVER}/${BUILD_ENGINE_DB}
 
 psql ${BUILD_ENGINE_URI} \
   --set ON_ERROR_STOP=1 --single-transaction --quiet \
-  --file sql/load_sources_simple.sql \
+  --file sql/load_sources.sql \
   --variable SCHEMA_NAME=${BUILD_ENGINE_SCHEMA}
 ```
 

--- a/import_tables.sql
+++ b/import_tables.sql
@@ -14,22 +14,6 @@ BEGIN;
 
 COMMIT;
 
-BEGIN;
-	COPY pluto (
-		"wkt",
-		"borough_id",
-		"block",
-		"lot",
-		"address",
-		"land_use_id",
-		"bbl"
-	)
-		FROM '../pluto.csv'
-		DELIMITER ','
-		CSV HEADER;
-
-COMMIT;
-
 INSERT INTO tax_lot
 SELECT
 	SUBSTRING(bbl, 1, 10) as bbl,

--- a/sql/load_sources.sql
+++ b/sql/load_sources.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS pluto;
+DROP TABLE IF EXISTS source_pluto;
 DROP INDEX IF EXISTS pluto_geom_idx;
-CREATE TABLE IF NOT EXISTS "pluto" (
+CREATE TABLE IF NOT EXISTS "source_pluto" (
 	"bbl" text PRIMARY KEY NOT NULL,
 	"borough" char(2) NOT NULL,
 	"block" text NOT NULL,
@@ -10,22 +10,22 @@ CREATE TABLE IF NOT EXISTS "pluto" (
 	"wkt" geometry
 );
 CREATE INDEX pluto_geom_idx
-  ON pluto
+  ON source_pluto
   USING GIST (wkt);
 
-\COPY pluto ("wkt", "borough", "block", "lot", "address", "land_use", "bbl") FROM './pluto.csv' DELIMITER ',' CSV HEADER;
+\COPY source_pluto ("wkt", "borough", "block", "lot", "address", "land_use", "bbl") FROM './pluto.csv' DELIMITER ',' CSV HEADER;
 
 
-DROP TABLE IF EXISTS zoning_districts;
+DROP TABLE IF EXISTS source_zoning_districts;
 DROP INDEX IF EXISTS zoning_districts_geom_idx;
-CREATE TABLE IF NOT EXISTS "zoning_districts" (
+CREATE TABLE IF NOT EXISTS "source_zoning_districts" (
 	"zonedist" text NOT NULL,
 	"shape_leng" float,
 	"shape_area" float,
 	"wkt" geometry
 );
 CREATE INDEX zoning_districts_geom_idx
-  ON zoning_districts
+  ON source_zoning_districts
   USING GIST (wkt);
 
-\COPY zoning_districts ("wkt", "zonedist", "shape_leng", "shape_area") FROM './zoning_districts.csv' DELIMITER ',' CSV HEADER;
+\COPY source_zoning_districts ("wkt", "zonedist", "shape_leng", "shape_area") FROM './zoning_districts.csv' DELIMITER ',' CSV HEADER;

--- a/sql/load_sources.sql
+++ b/sql/load_sources.sql
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS pluto;
+DROP INDEX IF EXISTS pluto_geom_idx;
+CREATE TABLE IF NOT EXISTS "pluto" (
+	"bbl" text PRIMARY KEY NOT NULL,
+	"borough" char(2) NOT NULL,
+	"block" text NOT NULL,
+	"lot" text NOT NULL,
+	"address" text,
+	"land_use" char(2),
+	"wkt" geometry
+);
+CREATE INDEX pluto_geom_idx
+  ON pluto
+  USING GIST (wkt);
+
+\COPY pluto ("wkt", "borough", "block", "lot", "address", "land_use", "bbl") FROM './pluto.csv' DELIMITER ',' CSV HEADER;
+
+
+DROP TABLE IF EXISTS zoning_districts;
+DROP INDEX IF EXISTS zoning_districts_geom_idx;
+CREATE TABLE IF NOT EXISTS "zoning_districts" (
+	"zonedist" text NOT NULL,
+	"shape_leng" float,
+	"shape_area" float,
+	"wkt" geometry
+);
+CREATE INDEX zoning_districts_geom_idx
+  ON zoning_districts
+  USING GIST (wkt);
+
+\COPY zoning_districts ("wkt", "zonedist", "shape_leng", "shape_area") FROM './zoning_districts.csv' DELIMITER ',' CSV HEADER;


### PR DESCRIPTION
resolves #3 

This uses a sql script to create tables for source data and populate them using csv files downloaded from Digital Ocean.

An unfortunate consequence of this approach is that we list all of the columns in the csv files and they must be listed in the same order as in the file.


### screenshots

Running the terminal command documented in the README:

<img width="689" alt="Screenshot 2024-03-14 at 5 39 27 PM" src="https://github.com/NYCPlanning/ae-data-flow/assets/7444289/818cc8bb-15c2-414c-89e1-2d8d57e6ff42">

Populated pluto table in the database:

<img width="898" alt="Screenshot 2024-03-14 at 5 40 37 PM" src="https://github.com/NYCPlanning/ae-data-flow/assets/7444289/98b109e0-e8ca-4fa4-8eb9-04a395acf1a9">


