### PR TITLE
67/check capital project category

### DIFF
--- a/drizzle/migration/schema.ts
+++ b/drizzle/migration/schema.ts
@@ -1,10 +1,5 @@
 import { pgEnum } from "drizzle-orm/pg-core";
 
-export const capital_project_category = pgEnum("capital_project_category", [
-  "Fixed Asset",
-  "Lump Sum",
-  "ITT, Vehicles and Equipment",
-]);
 export const category = pgEnum("category", [
   "Residential",
   "Commercial",

--- a/pg/model-transform/capital-planning.sql
+++ b/pg/model-transform/capital-planning.sql
@@ -41,7 +41,15 @@ SELECT
 	m_agency_acro AS managing_agency,
 	description,
 	min_date,
-	max_date
+	max_date,
+	-- spatial columns will be updated later
+	-- need their places held here to update category
+	null AS li_ft_m_pnt,
+	null AS li_ft_m_poly,
+	null AS mercator_label,
+	null AS mercator_fill_m_pnt,
+	null AS mercator_fill_m_poly,
+	type_category AS category
 FROM  source_capital_project;
 
 -- I know what you're thinking; this is a lot of repeated code.

--- a/pg/model-transform/capital-planning.sql
+++ b/pg/model-transform/capital-planning.sql
@@ -41,19 +41,7 @@ SELECT
 	m_agency_acro AS managing_agency,
 	description,
 	min_date,
-	max_date,
-  -- The enum in the API database drops the oxford comma
-  -- This was unintentional but the simplest way to rectify
-  -- the data source with the API database is to coerce the
-  -- source value to drop the oxford comma
-  CASE
-	 WHEN type_category = 'Fixed Asset' OR
-	 	type_category = 'Fixed Asset' OR
-		type_category IS NULL
-		THEN type_category::capital_project_category
-	 WHEN type_category = 'ITT, Vehicles, and Equipment'
-		THEN 'ITT, Vehicles and Equipment'::capital_project_category
-  END AS category
+	max_date
 FROM  source_capital_project;
 
 -- I know what you're thinking; this is a lot of repeated code.

--- a/pg/source-create/capital-planning.sql
+++ b/pg/source-create/capital-planning.sql
@@ -1,7 +1,7 @@
-DROP TABLE IF EXISTS 
-	source_capital_commitment, 
+DROP TABLE IF EXISTS
+	source_capital_commitment,
 	source_capital_project,
-	source_capital_project_m_poly, 
+	source_capital_project_m_poly,
 	source_capital_project_m_pnt
 	CASCADE;
 
@@ -41,9 +41,11 @@ CREATE TABLE IF NOT EXISTS  source_capital_project (
   proj_id text NOT NULL,
   min_date date,
   max_date date,
-  -- TODO: check that it satisfies the capital_project_category enum,
-  -- once the enum is fixed
-  type_category text,
+  type_category text CHECK (type_category IN (
+            'Fixed Asset',
+            'Lump Sum',
+            'ITT, Vehicles, and Equipment'
+            )),
   plannedcommit_ccnonexempt numeric,
   plannedcommit_ccexempt numeric,
   plannedcommit_citycost numeric,


### PR DESCRIPTION
Capital project category with check
Use a check constraint for capital project category

closes https://github.com/NYCPlanning/ae-data-flow/issues/67

***Note:*** *changes are split into two commits to enforce migration steps. These steps drop category data that contained a typo.*
