### PR TITLE
Fix budget response agency response newlines

### DIFF
--- a/pg/model-transform/community-board-budget-requests.sql
+++ b/pg/model-transform/community-board-budget-requests.sql
@@ -89,6 +89,7 @@ WHERE
 ALTER TABLE source_cbbr_export
     ADD COLUMN IF NOT EXISTS is_location_specific boolean,
 	ADD COLUMN IF NOT EXISTS is_continued_support boolean,
+	ADD COLUMN IF NOT EXISTS refined_agency_response text,
 	ADD COLUMN IF NOT EXISTS refined_managing_code text,
 	ADD COLUMN IF NOT EXISTS refined_m_agency_acro text,
 	ADD COLUMN IF NOT EXISTS refined_request_type text,
@@ -112,6 +113,13 @@ UPDATE source_cbbr_export
 			WHEN RIGHT(tracking_code, 1) = 'S' THEN True
 			ELSE False
 		END;
+
+UPDATE source_cbbr_export
+    -- Replace "\n" characters with line breaks, remove duplicates
+    SET refined_agency_response = REGEXP_REPLACE(
+    		REGEXP_REPLACE(agency_response, '\\n', E'\n', 'g'),
+    		'\n{2,}', E'\n'
+    	);
 
 UPDATE source_cbbr_export
 	SET refined_managing_code = LPAD(agency::TEXT, 3, '0');


### PR DESCRIPTION
- transform the agency response field of community board budget request table
- Replace "\n" characters with new lines

closes NYCPlanning/ae-cp-map#294

**Note:**
- This approach assumes that the desired data is to have a single, correct newline character.
- The newline character is now encoded correctly
- Browsers may default to rendering it as a space, rather than a whole new line. Because the character exists in the data, the text can be split into an array and renderned in different paragraphs. This is similar to the approach in  https://github.com/NYCPlanning/ae-cp-map/pull/295 . With these data changes however, the split would be on `\n`, instead of `\\n`. Also, there should be no need to filter empty lines.