### PR TITLE
Add first steps of having nta source data

### DIFF
--- a/build/schemas.ts
+++ b/build/schemas.ts
@@ -9,6 +9,7 @@ export const buildSchema = z.enum([
   "pluto",
   "city-council-districts",
   "capital-planning",
+  "neighborhood-tabulation-areas",
 ]);
 export type Build = z.infer<typeof buildSchema>;
 
@@ -57,6 +58,11 @@ export const buildTree: Array<BuildNode> = [
   {
     name: "pluto",
     parents: ["boroughs"],
+    children: [],
+  },
+  {
+    name: "neighborhood-tabulation-areas",
+    parents: [],
     children: [],
   },
 ];

--- a/minio/download.ts
+++ b/minio/download.ts
@@ -19,7 +19,9 @@ import "dotenv/config";
           | "datasets/dcp_city_council_districts/24B"
           | "datasets/dcp_community_districts/24B"
           | "datasets/dcp_borough_boundary/production"
-          | "db-cbbr/publish/latest";
+          | "db-cbbr/publish/latest"
+          | "datasets/dcp_nta_2010/24B"
+          | "datasets/dcp_nta_2020/24B";
       }
     | {
         bucketName: "ae-data-backups";
@@ -122,6 +124,20 @@ import "dotenv/config";
       bucketName: "edm-recipes",
       bucketSubPath: "inbox/dcp/dcp_managing_agencies_lookup/20250725",
       build: "agencies",
+    },
+    {
+      fileName: "dcp_nta_2010",
+      fileExtension: "zip",
+      bucketName: "edm-publishing",
+      bucketSubPath: "datasets/dcp_nta_2010/24B",
+      build: "neighborhood-tabulation-areas",
+    },
+    {
+      fileName: "dcp_nta_2020",
+      fileExtension: "zip",
+      bucketName: "edm-publishing",
+      bucketSubPath: "datasets/dcp_nta_2020/24B",
+      build: "neighborhood-tabulation-areas",
     },
   ];
 

--- a/pg/source-create/neighborhood-tabulation-areas.sql
+++ b/pg/source-create/neighborhood-tabulation-areas.sql
@@ -1,0 +1,30 @@
+DROP TABLE IF EXISTS
+    source_neighborhood_tabulation_areas_2010,
+    source_neighborhood_tabulation_areas_2020,
+    CASCADE;
+
+CREATE TABLE IF NOT EXISTS source_neighborhood_tabulation_area_2010 (
+    borough_code char(1),
+    borough_name text,
+    county_fips text,
+    nta_code text,
+    nta_name text,
+    shape_leng float,
+    shape_area float,
+    wkt geometry(MULTIPOLYGON, 4326) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS source_neighborhood_tabulation_area_2020 (
+    borough_code char(1),
+    borough_name text,
+    county_fips text,
+    nta_2020 text,
+    nta_name text,
+    nta_abbrev text,
+    nta_type text,
+    cdta_2020 text,
+    cdta_name text,
+    shape_leng float,
+    shape_area float,
+    wkt geometry(MULTIPOLYGON, 4326) NOT NULL
+);

--- a/pg/source-load/load.ts
+++ b/pg/source-load/load.ts
@@ -277,6 +277,42 @@ import { Build } from "../../build/schemas";
       fileName: "zoning_district_class.csv",
       build: "pluto",
     },
+    {
+      table: "source_neighborhood_tabulation_area_2010",
+      columns: [
+        "borough_code",
+        "borough_name",
+        "county_fips",
+        "nta_code",
+        "nta_name",
+        "shape_leng",
+        "shape_area",
+        "wkt",
+      ],
+      filePath: "data/convert",
+      fileName: "dcp_nta_2010.csv",
+      build: "neighborhood-tabulation-areas",
+    },
+    {
+      table: "source_neighborhood_tabulation_area_2020",
+      columns: [
+        "borough_code",
+        "borough_name",
+        "county_fips",
+        "nta_2020",
+        "nta_name",
+        "nta_abbrev",
+        "nta_type",
+        "cdta_2020",
+        "cdta_name",
+        "shape_leng",
+        "shape_area",
+        "wkt",
+      ],
+      filePath: "data/convert",
+      fileName: "dcp_nta_2020.csv",
+      build: "neighborhood-tabulation-areas",
+    },
   ];
 
   const sqlTemplate = fs.readFileSync(`pg/source-load/load.sql`).toString();

--- a/shp/convert.ts
+++ b/shp/convert.ts
@@ -43,6 +43,16 @@ import { buildSources } from "../build/parse-build";
       build: "capital-planning",
       promoteToMulti: true,
     },
+    {
+      fileName: "dcp_nta_2010",
+      build: "neighborhood-tabulation-areas",
+      promoteToMulti: true,
+    },
+    {
+      fileName: "dcp_nta_2020",
+      build: "neighborhood-tabulation-areas",
+      promoteToMulti: true,
+    },
   ];
 
   const conversion = async (source: Source) => {


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-data-flow/issues/125

Some notes:
- added a new build `neighborhood-tabulation-areas`
- Using version 24B to be consistent. That's the version of city council districts and community districts we're also pulling from

To test, run `BUILD=neighborhood-tabulation-areas npm run flow`. This will fail once the build gets to step 6 (creating model tables from zoning-api). But this should result in zip files in `data/download`, csvs in `data/convert`, and two populated tables, `neighborhood_tabulation_area_2010` and `neighborhood_tabulation_area_2020`. 