### PR TITLE
Add census tract model tables

### DIFF
--- a/db/pg/model-create/all.sh
+++ b/db/pg/model-create/all.sh
@@ -39,6 +39,7 @@ pg_dump --host=$TARGET_DATABASE_HOST  \
     -t capital_commitment \
     -t capital_commitment_fund \
     -t neighborhood_tabulation_area \
+    -t census_tract \
     --file ./data/all_dump.sql
 
 PGPASSWORD=$POSTGRES_PASSWORD \

--- a/db/pg/model-create/all.sql
+++ b/db/pg/model-create/all.sql
@@ -24,5 +24,6 @@ DROP TABLE IF EXISTS
 	budget_line,
 	capital_commitment,
 	capital_commitment_fund,
-	neighborhood_tabulation_area
+	neighborhood_tabulation_area,
+	census_tract
     CASCADE

--- a/db/pg/model-create/census-tracts.sh
+++ b/db/pg/model-create/census-tracts.sh
@@ -1,0 +1,25 @@
+PGPASSWORD=$POSTGRES_PASSWORD \
+psql --host=localhost \
+    --port=5432 \
+    -U $POSTGRES_USER \
+    -d $POSTGRES_DB \
+    --single-transaction \
+    --file ./flow/model-create/census-tracts.sql
+
+PGPASSWORD=$TARGET_DATABASE_PASSWORD \
+pg_dump --host=$TARGET_DATABASE_HOST  \
+    --port=$TARGET_DATABASE_PORT \
+    -U $TARGET_DATABASE_USER \
+    -d $TARGET_DATABASE_NAME \
+    -s \
+    --no-owner \
+    -t census_tract \
+    --file ./data/census-tracts_dump.sql
+
+PGPASSWORD=$POSTGRES_PASSWORD \
+psql --host=localhost \
+    --port=5432 \
+    -U $POSTGRES_USER \
+    -d $POSTGRES_DB \
+    --single-transaction \
+    --file ./data/census-tracts_dump.sql

--- a/db/pg/model-create/census-tracts.sql
+++ b/db/pg/model-create/census-tracts.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS
+    census_tract 
+    CASCADE


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-data-flow/issues/145 

Switch local zoning-api branch to [594/create-census-tract-schema](https://github.com/NYCPlanning/ae-zoning-api/tree/594/create-census-tract-schema)

To test:
run `BUILD=census-tracts npm run flow` and you should see an empty `census-tract` table with the appropriate columns in the data flow DB