### PR TITLE
Transform and populate facility operator

### DIFF
--- a/db/pg/model-create/all.sh
+++ b/db/pg/model-create/all.sh
@@ -40,6 +40,7 @@ pg_dump --host=$TARGET_DATABASE_HOST  \
     -t capital_commitment_fund \
     -t neighborhood_tabulation_area \
     -t census_tract \
+    -t facility_operator \
     --file ./data/all_dump.sql
 
 PGPASSWORD=$POSTGRES_PASSWORD \

--- a/db/pg/model-create/all.sql
+++ b/db/pg/model-create/all.sql
@@ -25,5 +25,6 @@ DROP TABLE IF EXISTS
 	capital_commitment,
 	capital_commitment_fund,
 	neighborhood_tabulation_area,
-	census_tract
+	census_tract,
+	facility_operator
     CASCADE

--- a/db/pg/model-create/facilities.sh
+++ b/db/pg/model-create/facilities.sh
@@ -14,7 +14,7 @@ pg_dump --host=$TARGET_DATABASE_HOST  \
     -s \
     --no-owner \
     -t facility_operator \
-    --file ./data/facilities.sql
+    --file ./data/facilities_dump.sql
 
 PGPASSWORD=$POSTGRES_PASSWORD \
 psql --host=localhost \
@@ -22,4 +22,4 @@ psql --host=localhost \
     -U $POSTGRES_USER \
     -d $POSTGRES_DB \
     --single-transaction \
-    --file ./data/facilities.sql
+    --file ./data/facilities_dump.sql

--- a/db/pg/model-create/facilities.sql
+++ b/db/pg/model-create/facilities.sql
@@ -1,3 +1,3 @@
 DROP TABLE IF EXISTS
     facility_operator
-    CASCADE
+CASCADE;

--- a/db/pg/target-populate/all.sql
+++ b/db/pg/target-populate/all.sql
@@ -23,7 +23,10 @@ TRUNCATE
 	budget_line,
 	capital_commitment,
 	capital_commitment_fund,
-	capital_project_checkbook
+	capital_project_checkbook,
+	census_tract,
+	neighborhood_tabulation_area,
+	facility_operator
 RESTART IDENTITY
 CASCADE;
 
@@ -57,3 +60,8 @@ CASCADE;
 \copy budget_line FROM '/var/lib/postgresql/data/budget_line.csv';
 \copy capital_commitment FROM '/var/lib/postgresql/data/capital_commitment.csv';
 \copy capital_commitment_fund FROM '/var/lib/postgresql/data/capital_commitment_fund.csv';
+
+\copy census_tract from '/var/lib/postgresql/data/census_tract.csv';
+\copy neighborhood_tabulation_area from '/var/lib/postgresql/data/neighborhood_tabulation_area.csv';
+\copy facility_operator from '/var/lib/postgresql/data/facility_operator.csv';
+ 

--- a/db/pg/target-populate/facilities.sql
+++ b/db/pg/target-populate/facilities.sql
@@ -1,0 +1,5 @@
+TRUNCATE
+    facility_operator
+    CASCADE;
+
+\copy facility_operator FROM '/var/lib/postgresql/data/facility_operator.csv';

--- a/minio/download.ts
+++ b/minio/download.ts
@@ -161,7 +161,7 @@ import "dotenv/config";
       fileName: "facilities",
       fileExtension: "csv",
       bucketName: "edm-publishing",
-      bucketSubPath: "db-facilities/publish/25v2",
+      bucketSubPath: "db-facilities/build/nightly_qa",
       build: "facilities",
     },
     {

--- a/pg/model-transform/facilities.sql
+++ b/pg/model-transform/facilities.sql
@@ -1,0 +1,29 @@
+TRUNCATE
+    facility_operator
+    CASCADE;
+
+DROP TABLE IF EXISTS facility_operator_all CASCADE;
+
+CREATE TABLE IF NOT EXISTS facility_operator_all (
+    abbreviation text,
+    name text,
+    type text
+);
+
+INSERT INTO facility_operator_all (
+    abbreviation, 
+    name, 
+    type
+)
+SELECT DISTINCT
+    "OPABBREV" as abbreviation,
+    "OPNAME" as name,
+    "OPTYPE" as type
+FROM source_facility
+WHERE "OPNAME" IS NOT NULL;
+
+INSERT INTO facility_operator
+SELECT gen_random_uuid() as id, *
+FROM facility_operator_all;
+
+COPY facility_operator TO '/var/lib/postgresql/data/facility_operator.csv';


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-data-flow/issues/156

Notes: 

- Running `BUILD=facilities npm run flow` should populate the `facility_operator` table in zoning-api
- Currently, only checking that the operator name is not null, so we should expect null abbreviations. 
- There are many facilities with null operator name and abbreviation. While DE determines whether that is [allowed](https://github.com/NYCPlanning/ae-data-flow/issues/122#issuecomment-4452019547), I opted to not have a record for NULL, NULL in this table. 