### PR TITLE
Agencies table: add new columns - transform and populate

### DIFF
--- a/minio/download.ts
+++ b/minio/download.ts
@@ -12,30 +12,30 @@ import "dotenv/config";
     fileExtension: "csv" | "zip";
     build: Build;
   } & (
-      | {
+    | {
         bucketName: "edm-publishing";
         bucketSubPath:
-        | "db-cpdb/publish/latest"
-        | "datasets/dcp_city_council_districts/24B"
-        | "datasets/dcp_community_districts/24B"
-        | "datasets/dcp_borough_boundary/production"
-        | "db-cbbr/publish/latest"
-        | "datasets/dcp_nta_2010/24B"
-        | "datasets/dcp_nta_2020/24B"
-        | "datasets/dcp_census_tracts_2010/23B"
-        | "datasets/dcp_census_tracts_2020/25D"
-        | "db-facilities/publish/25v2"
-        | "db-facilities/build/nightly_qa";
+          | "db-cpdb/publish/latest"
+          | "datasets/dcp_city_council_districts/24B"
+          | "datasets/dcp_community_districts/24B"
+          | "datasets/dcp_borough_boundary/production"
+          | "db-cbbr/publish/latest"
+          | "datasets/dcp_nta_2010/24B"
+          | "datasets/dcp_nta_2020/24B"
+          | "datasets/dcp_census_tracts_2010/23B"
+          | "datasets/dcp_census_tracts_2020/25D"
+          | "db-facilities/publish/25v2"
+          | "db-facilities/build/nightly_qa";
       }
-      | {
+    | {
         bucketName: "ae-data-backups";
         bucketSubPath: "zoning-api";
       }
-      | {
+    | {
         bucketName: "edm-recipes";
-        bucketSubPath: "inbox/dcp/dcp_managing_agencies_lookup/20250725";
+        bucketSubPath: "inbox/dcp/dcp_managing_agencies_lookup/20260222";
       }
-    );
+  );
 
   const sourcesToDownload: Array<Source> = [
     {
@@ -126,7 +126,7 @@ import "dotenv/config";
       fileName: "dcp_managing_agencies_lookup",
       fileExtension: "csv",
       bucketName: "edm-recipes",
-      bucketSubPath: "inbox/dcp/dcp_managing_agencies_lookup/20250725",
+      bucketSubPath: "inbox/dcp/dcp_managing_agencies_lookup/20260222",
       build: "agencies",
     },
     {

--- a/pg/model-transform/agencies.sql
+++ b/pg/model-transform/agencies.sql
@@ -3,19 +3,21 @@ TRUNCATE
     managing_code
     CASCADE;
 
-INSERT INTO agency (initials, name)
+INSERT INTO agency (initials, name, oversight_level)
 SELECT DISTINCT
     managing_agency_acronym as initials,
-    managing_agency as name
+    managing_agency as name,
+    NULLIF(overlevel, '') AS oversight_level
 FROM source_agency;
 
 INSERT INTO agency (initials, name)
     VALUES
         ('OCA', 'Office of Court Administration'),
         -- Community board budget requests list "other" as an agency option
-        ('OTH', 'Other'),
-        ('MTA', 'Metropolitan Transportation Authority');
-
+        ('OTH', 'Other');
+-- NYCRGB and SUNY have blank names the below is updating the table to include the names
+UPDATE agency SET name = 'NYC Rent Guidelines Board' WHERE initials = 'NYCRGB';
+UPDATE agency SET name = 'State University of New York' WHERE initials = 'SUNY';
 INSERT INTO managing_code (id)
 SELECT DISTINCT
 	agency_code AS id

--- a/pg/source-create/agencies.sql
+++ b/pg/source-create/agencies.sql
@@ -3,8 +3,12 @@ DROP TABLE IF EXISTS
     CASCADE;
 
 CREATE TABLE IF NOT EXISTS source_agency (
-    agency_code char(3),
-    source text,
     managing_agency_acronym text,
-    managing_agency text
+    managing_agency text,
+    source text,
+    manages_capital_projects boolean,
+    operates_facilities boolean,
+    agency_code char(3),
+    overlevel text,
+    optype text
 );

--- a/pg/source-load/load.ts
+++ b/pg/source-load/load.ts
@@ -20,10 +20,14 @@ import { Build } from "../../build/schemas";
     {
       table: "source_agency",
       columns: [
-        "agency_code",
-        "source",
         "managing_agency_acronym",
         "managing_agency",
+        "source",
+        "manages_capital_projects",
+        "operates_facilities",
+        "agency_code",
+        "overlevel",
+        "optype",
       ],
       filePath: "data/download",
       fileName: "dcp_managing_agencies_lookup.csv",
@@ -404,33 +408,21 @@ import { Build } from "../../build/schemas";
     },
     {
       table: "source_facility_category",
-      columns: [
-        "id",
-        "category",
-        "description",
-      ],
+      columns: ["id", "category", "description"],
       filePath: "data",
       fileName: "facility_category.csv",
       build: "facilities",
     },
     {
       table: "source_facility_group",
-      columns: [
-        "id",
-        "group",
-        "description",
-      ],
+      columns: ["id", "group", "description"],
       filePath: "data",
       fileName: "facility_group.csv",
       build: "facilities",
     },
     {
       table: "source_facility_subgroup",
-      columns: [
-        "id",
-        "subgroup",
-        "description",
-      ],
+      columns: ["id", "subgroup", "description"],
       filePath: "data",
       fileName: "facility_subgroup.csv",
       build: "facilities",


### PR DESCRIPTION
#### Description
Agencies table updates
 - added agencies from new lookup table 
 - transformed and populated oversight_level column


<details>
<summary>Horatio's testing steps: </summary>
#### Steps
 - [x] Before `db:pg:model:create` confirm `agency` tables does not exist (sanity check)
<img width="262" height="363" alt="agency-table-does-not-exist" src="https://github.com/user-attachments/assets/231e6a4b-e361-49aa-8f88-3f5ba9affe51" />
<br><br>

- [x] After  `db:pg:model:create` confirm `agency` tables does exist with correct schema

<img width="280" height="386" alt="agency-table-exists" src="https://github.com/user-attachments/assets/01a170fd-62ca-44ea-9376-33ab09e67a04" />
<img width="697" height="429" alt="agency-schema-after" src="https://github.com/user-attachments/assets/d9687efe-11c8-4a2a-b733-b35291c079f5" />
<br><br>

 - [x] Before `pg:model:transform` confirm `agency`table is empty of data
<img width="1292" height="319" alt="agency-table-no-data" src="https://github.com/user-attachments/assets/64e04e10-ebbd-41f8-9a26-62ace8638c70" />
<br><br>

- [x] After `pg:model:transform` confirm `agency` table are contains the data expected
<img width="1647" height="473" alt="agency-table-transform" src="https://github.com/user-attachments/assets/0fa7fbbe-5ff7-45bd-85cd-561c94b3efa0" />
<img width="1081" height="599" alt="agncy-table-with-data" src="https://github.com/user-attachments/assets/824cfdd9-61d3-40c4-bc65-51d865366661" />
<br><br>

- [x] Before `db:pg:target:populate` confirm `agency` table in the zoning api database is empty (sanity check)

<img width="1209" height="525" alt="agency-table-zoning-api-empty" src="https://github.com/user-attachments/assets/09ee158c-d2c7-4cea-b477-973d2e21180a" />

- [x] After `db:pg:target:populate` confirm `agency` table  data in the flow database populate the `agency` table in the zoning api database
<br><br>
<img width="1922" height="740" alt="agency-populate" src="https://github.com/user-attachments/assets/5d3f434d-c661-48ec-b6b4-76d4ca32d0d5" />
<img width="1150" height="638" alt="agency-table-zoning-api-with-data" src="https://github.com/user-attachments/assets/d65f6d38-31e5-432f-93a2-34d4ff380dfd" />
</details>

#### Notes
* As mentioned, we have duplicate agencies due to pulling them from both capital-project and facilities to create the lookup table. Below is an example. DE will do the work to consolidate these agencies and once they do, we will have to address how to handle that in the facilities table. (e.g. coerce the data `NYCDOE` in the overseeing_agency_initials to `DOE`). <img width="3110" height="1092" alt="image" src="https://github.com/user-attachments/assets/ca65b911-d1ac-4bb9-9f08-4a41b39da5fb" />
* But for now, in the interest of time and a looming deadline, we can keep these duplicates since they should not impact capital projects or CBBRs. I do want us to doublecheck that the way we populate the agencies dropdown in cp-map would not be impacted by these duplicates 

#### Tickets
Closes #141 