### PR TITLE
Add facilities options tables to model create step

### DIFF
--- a/data/facility_category.csv
+++ b/data/facility_category.csv
@@ -1,0 +1,8 @@
+﻿id,category,description
+1,"Education, Child Welfare, and Youth","Providers of children and youth services and all schools, including higher education facilities"
+2,"Parks, Gardens, and Historical Sites","Historic sites, recreational areas, parks, and nature preserves"
+3,Libraries and Cultural Programs,Public Libraries and Cultural Institutions
+4,"Public Safety, Emergency Services, and Administration of Justice","Police services, emergency response, courthouses, and correctional facilities"
+5,Health and Human Services,"Health and social service providers, including hospitals, legal services, and homeless shelters"
+6,Core Infrastructure and Transportation,"Train and bus yards, parking lots, solid waste processors, and wastewater treatment plants"
+7,Administration of Government,"Sites owned or leased by the City for administration, operations, and maintenance"

--- a/data/facility_group.csv
+++ b/data/facility_group.csv
@@ -1,0 +1,26 @@
+﻿id,group,description
+1,Schools (K-12),K-12 and alternative equivalency programs overseen by NYC Dept. of Education and NYS Education Department
+2,Day Care and Pre-Kindergarten,Childcare centers overseen by NYC Administration for Childrens Services and NYC Dept. of Mental Health and Hygiene
+3,Child Services and Welfare,Services overseen by NYC Health and Human Services and NYC Administration for Children's Services
+4,Youth Services,Services overseen by NYC Dept. of Youth and Community Development
+5,Adult Services,
+6,Camps,Camps overseen by NYC Dept. of Mental Health and Hygiene
+7,Higher Education,Public and privately operated 2 and 4 year colleges and universities
+8,Vocational and Proprietary Schools,ESL schools and trade colleges
+9,Parks and Plazas,"Properties operated by NYC Parks, NYC Dept. of Transportation, NYS Office of Parks, Recreation and Historic Preservation, NYS Dept. of Conservation, and City-State corporations and trusts"
+10,Historical Sites,"Sites operated by NYC Parks, NYS Office of Parks, Recreation and Historic Preservation, and US National Park Service"
+11,Libraries,"Libraries operated by New York Public Libraries, Queens Public Libraries, and Brooklyn Public Libraries and academic institutions"
+12,Cultural Institutions,Institutions licensed or funded by the NYC Dept. of Cultural Affairs
+13,Emergency Services,Services provided by Fire Dept. of New York
+14,Public Safety,Services provided by New York Police Dept. and New York Housing Authority Police
+15,Justice and Corrections,"Courts and correctional facilities operated by NYC. Dept. of Correction, NYS Unified Court System, NYS Dept. of Corrections and Community Supervision, US Courts, and Federal Bureau of Prisons"
+16,Health Care,"Health facilities overseen by NYC Health and Hospitals Corporation, NYC Health and Human Services, NYS Dept. of Health, NYS Office of Mental Health, and NYS Office of Addiction Services and Supports"
+17,Human Services,"Services overseen by NYC Dept. of Homeless Services, NYC Dept. of Human Resources, NYC Mayorality, and others"
+18,Solid Waste,"Sites overseen and operated by NYC Dept. of Sanitation, NYC Business Integrity Commission, and NYS Dept. of Conservation"
+19,Water and Wastewater,Sites overseen and operated by NYC Dept. of Environmental Protection
+20,Transportation,"Sites operated or overseen by Metropolitan Transportation Authority, Port Authority of NY and NJ, NYC Dept. of Transportation, NYC Dept. of Consumer Affairs, US Dept. of Transportation, and others"
+21,Telecommunications,Sites operated or overseen by Dept. of Information Technology and Telecommunications and other City telecommunications services
+22,Material Supplies and Markets,Sites operated or overseen by Dept. of Information Technology and Telecommunications and other City telecommunications services
+23,"Offices, Training, and Testing",All City owned or leased offices overseen by Dept. of Citywide Administrative Services
+24,"City Agency Parking, Maintenance, and Storage",City owned or leased properites used for City vehicle and equipment-related operations by Dept. of Citywide Administrative Services
+25,Other Property,City owned or leased property without a categorized use overseen by Dept. of Citywide Administrative Services

--- a/data/facility_subgroup.csv
+++ b/data/facility_subgroup.csv
@@ -1,0 +1,73 @@
+﻿id,subgroup,description
+1,Public K-12 Schools,"Public elementary, middle, and high schools"
+2,Charter K-12 Schools,"Publically funded charter elementary, middle, and high schools"
+3,Non-Public K-12 Schools,"Private elementary, middle, and high schools"
+4,Public and Private Special Education Schools,Specialized schools and educational services for students with disabilities
+5,GED and Alternative High School Equivalency,Alternative programs for obtaining high school equivalency degree
+6,DOE Universal Pre-Kindergarten,NYC DOE designated Universal Pre-K center
+7,Day Care,"Group and school-based child care centers for infants, toddlers, and preschoolers"
+8,Preschools for Students with Disabilities,Center specialized on preschool students with disabilities
+9,Head Start,Federal program promoting school readiness for children up to age five
+10,Child Nutrition,"Summer and year-round child feeding centers, either based at NYC Dept of Education schools or tracked by New York State Education Department"
+11,"Youth Centers, Literacy Programs, and Job Training Services","Youth Centers, Literacy Programs, and Job Training Services"
+12,After-School Programs,After-School Programs
+13,Adult and Immigrant Literacy,Adult and Immigrant Literacy
+14,Camps,Preschool age and all age camps
+15,Colleges or Universities,Public and privately operated 2 and 4 year colleges and universities
+16,Proprietary Schools,ESL schools and trade colleges
+17,Parks,"Flagship parks, community parks, state parks, and city-state parks"
+18,Recreation and Waterfront Sites,"Playgrounds, waterfront facilities, and recreation fields and courts"
+19,"Streetscapes, Plazas, and Malls","Pedestrian plazas, malls, triangle plazas, and parkways"
+20,Gardens,Community gardens
+21,Privately Owned Public Space,"Plazas, arcades, and other open space provided for public use by a private office or residential building owner"
+22,Preserves and Conservation Areas,"Nature areas, preserves, wetlands, and state forests"
+23,Cemeteries,Cemeteries operated by NYC Parks
+24,Undeveloped,Undeveloped parks land
+25,Historical Sites,"Historic house parks, State historic places, national monuments, and national memorials"
+26,Public Libraries,All public libaries
+27,Academic and Special Libraries,Libraries operated by academic institutions or other specialized organizations
+28,Museums,Publicly and privately operated museums
+29,Historical Societies,Historical societies
+30,Other Cultural Institutions,"Zoos, botanical gardens, performing arts centers, and multi-disciplinary art centers"
+31,Fire Services,Firehouses
+32,Other Emergency Services,Ambulance and Emergency Medical Stations
+33,Police Services,NYPD and NYCHA police stations
+34,Other Public Safety,Other public safety related support centers
+35,Courthouses and Judicial,"Courthouses, clerk offices, and court librarians"
+36,Detention and Correctional,Correctional and dentention centers
+37,Hospitals and Clinics,"Urgent care hospitals, diagnostic and treatment centers, and school-based health facilities"
+38,Mental Health,"Inpatient, outpatient, and emergency mental health services"
+39,Residential Health Care,"Nursing homes, hospice care, and supportive housing"
+40,Substance Use Disorder Treatment Programs,"Monitored support, inpatient, outpatient, and crisis services"
+41,Health Promotion and Disease Prevention,Programs focused on improving health through education and disease prevention
+42,Other Health Care,"Rehab, respite servies, vaccination services, AIDS counseling, and home health centers"
+43,Senior Services,"Neighborhood senior centers, meal delivery programs, and other services for seniors"
+44,Immigrant Services,Immigrant Services
+45,Community Centers and Community Programs,Community centers that provide multiple social services at one site
+46,Financial Assistance and Social Services,"SNAP, Child Support, and Medicaid Centers operated by NYC Human Resources Administration"
+47,Workforce Development,Workforce 1 Centers and other vocational services for adults
+48,Legal and Intervention Services,"Early intervention, criminal defense, and mediation services"
+49,Programs for People with Disabilities,"Specialized child care, caregiver support, and recreational services"
+50,Non-residential Housing and Homeless Services,Non-residential homelessness prevention services
+51,Soup Kitchens and Food Pantries,Soup kitchens and food pantries
+52,Solid Waste Processing,"Material recovery, composting, landfill gas recovery, and scrap metal processing facilities"
+53,Solid Waste Transfer and Carting,Waste carter sites and transfer stations
+54,DSNY Drop-Off Facility,Locations where New York City residents can drop-off certain harmful products
+55,Wastewater and Pollution Control,Wastewater treatment plants and other sites related to wastewater conveyance and pollution control
+56,Water Supply,Sites related to water supply
+57,Parking Lots and Garages,Publicly and commerially operated parking lots and garages
+58,Bus Depots and Terminals,"School bus depots, MTA bus depots, and Port Authority bus terminals"
+59,Rail Yards and Maintenance,Rail yards and maintenance facilities
+60,Ports and Ferry Landings,"Ferry landings, cruise terminals, and ports"
+61,Airports and Heliports,"Publicly and privately operated airports, heliports, and seaplane bases"
+62,Other Transportation,Uncategorized transportation related sites
+63,Telecommunications,Antennas and other telecommunications sites
+64,Material Supplies,Asphalt plants and other material processing facilities
+65,Wholesale Markets,Wholesale food and commercial markets
+66,City Government Offices,Offices used by City agencies
+67,Training and Testing,Training and testing sites used by City agencies
+68,Custodial,City agency custodial sites
+69,Maintenance and Garages,City agency vehicle maintenance sites
+70,City Agency Parking,City agency parking lots
+71,Storage,City agency storage sites
+72,Miscellaneous Use,Property without a categorized use

--- a/db/pg/model-create/all.sh
+++ b/db/pg/model-create/all.sh
@@ -41,6 +41,10 @@ pg_dump --host=$TARGET_DATABASE_HOST  \
     -t neighborhood_tabulation_area \
     -t census_tract \
     -t facility_operator \
+    -t facility_domain \
+    -t facility_group \
+    -t facility_subgroup \
+    -t facility_type \
     --file ./data/all_dump.sql
 
 PGPASSWORD=$POSTGRES_PASSWORD \

--- a/db/pg/model-create/all.sql
+++ b/db/pg/model-create/all.sql
@@ -26,5 +26,9 @@ DROP TABLE IF EXISTS
 	capital_commitment_fund,
 	neighborhood_tabulation_area,
 	census_tract,
-	facility_operator
+	facility_operator,
+	facility_type,
+    facility_subgroup,
+    facility_group,
+    facility_domain
     CASCADE

--- a/db/pg/model-create/facilities.sh
+++ b/db/pg/model-create/facilities.sh
@@ -14,6 +14,10 @@ pg_dump --host=$TARGET_DATABASE_HOST  \
     -s \
     --no-owner \
     -t facility_operator \
+    -t facility_domain \
+    -t facility_group \
+    -t facility_subgroup \
+    -t facility_type \
     --file ./data/facilities_dump.sql
 
 PGPASSWORD=$POSTGRES_PASSWORD \

--- a/db/pg/model-create/facilities.sql
+++ b/db/pg/model-create/facilities.sql
@@ -1,3 +1,7 @@
 DROP TABLE IF EXISTS
-    facility_operator
+    facility_operator,
+    facility_type,
+    facility_subgroup,
+    facility_group,
+    facility_domain
 CASCADE;

--- a/pg/source-create/facilities.sql
+++ b/pg/source-create/facilities.sql
@@ -1,4 +1,7 @@
 DROP TABLE IF EXISTS
+  source_facility_category,
+  source_facility_group,
+  source_facility_subgroup,
 	source_facility
 	CASCADE;
 
@@ -40,4 +43,22 @@ CREATE TABLE IF NOT EXISTS source_facility (
   "POLICEPRCT" numeric,
   "DATASOURCE" text,
   "UID" text
+);
+
+CREATE TABLE IF NOT EXISTS source_facility_category (
+  "id" text,
+  "category" text,
+  "description" text
+);
+
+CREATE TABLE IF NOT EXISTS source_facility_group (
+  "id" text,
+  "group" text,
+  "description" text
+);
+
+CREATE TABLE IF NOT EXISTS source_facility_subgroup (
+  "id" text,
+  "subgroup" text,
+  "description" text
 );

--- a/pg/source-load/load.ts
+++ b/pg/source-load/load.ts
@@ -403,6 +403,39 @@ import { Build } from "../../build/schemas";
       build: "facilities",
     },
     {
+      table: "source_facility_category",
+      columns: [
+        "id",
+        "category",
+        "description",
+      ],
+      filePath: "data",
+      fileName: "facility_category.csv",
+      build: "facilities",
+    },
+    {
+      table: "source_facility_group",
+      columns: [
+        "id",
+        "group",
+        "description",
+      ],
+      filePath: "data",
+      fileName: "facility_group.csv",
+      build: "facilities",
+    },
+    {
+      table: "source_facility_subgroup",
+      columns: [
+        "id",
+        "subgroup",
+        "description",
+      ],
+      filePath: "data",
+      fileName: "facility_subgroup.csv",
+      build: "facilities",
+    },
+    {
       table: "source_data_sources",
       columns: [
         "schema_name",


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-data-flow/issues/142

This PR relies on the zoning-api schemas https://github.com/NYCPlanning/ae-zoning-api/pull/625

Running `BUILD=all npm run flow` or `BUILD=facilities npm run flow` should create model tables `facility_domain`, `facility_group`, `facility_subgroup`, and `facility_type` in the data-flow db 