### PR TITLE
144/transform and populate facilities' options tables

### DIFF
--- a/db/pg/target-populate/all.sql
+++ b/db/pg/target-populate/all.sql
@@ -27,6 +27,10 @@ TRUNCATE
 	census_tract,
 	neighborhood_tabulation_area,
 	facility_operator,
+    facility_type,
+    facility_subgroup,
+    facility_group,
+    facility_domain,
 	data_source
 RESTART IDENTITY
 CASCADE;
@@ -65,4 +69,8 @@ CASCADE;
 \copy census_tract from '/var/lib/postgresql/data/census_tract.csv';
 \copy neighborhood_tabulation_area from '/var/lib/postgresql/data/neighborhood_tabulation_area.csv';
 \copy facility_operator from '/var/lib/postgresql/data/facility_operator.csv';
+\copy facility_domain FROM '/var/lib/postgresql/data/facility_domain.csv';
+\copy facility_group FROM '/var/lib/postgresql/data/facility_group.csv';
+\copy facility_subgroup FROM '/var/lib/postgresql/data/facility_subgroup.csv';
+\copy facility_type FROM '/var/lib/postgresql/data/facility_type.csv';
 \copy data_source from '/var/lib/postgresql/data/data_source.csv';

--- a/db/pg/target-populate/facilities.sql
+++ b/db/pg/target-populate/facilities.sql
@@ -1,5 +1,13 @@
 TRUNCATE
-    facility_operator
+    facility_operator,
+    facility_type,
+    facility_subgroup,
+    facility_group,
+    facility_domain
     CASCADE;
 
 \copy facility_operator FROM '/var/lib/postgresql/data/facility_operator.csv';
+\copy facility_domain FROM '/var/lib/postgresql/data/facility_domain.csv';
+\copy facility_group FROM '/var/lib/postgresql/data/facility_group.csv';
+\copy facility_subgroup FROM '/var/lib/postgresql/data/facility_subgroup.csv';
+\copy facility_type FROM '/var/lib/postgresql/data/facility_type.csv';

--- a/pg/model-transform/facilities.sql
+++ b/pg/model-transform/facilities.sql
@@ -1,6 +1,11 @@
 TRUNCATE
-    facility_operator
-    CASCADE;
+    facility_operator,
+    facility_type,
+    facility_subgroup,
+    facility_group,
+    facility_domain
+RESTART IDENTITY
+CASCADE;
 
 DROP TABLE IF EXISTS facility_operator_all CASCADE;
 
@@ -26,4 +31,39 @@ INSERT INTO facility_operator
 SELECT gen_random_uuid() as id, *
 FROM facility_operator_all;
 
+INSERT INTO facility_domain (name, description)
+SELECT DISTINCT
+    "category" as name,
+    "description" as description
+FROM source_facility_category;
+
+INSERT INTO facility_group (name, description, facility_domain_id)
+SELECT DISTINCT
+    source_facility_group.group as name,
+    source_facility_group.description as description,
+    facility_domain.id as facility_domain_id
+FROM source_facility_group
+LEFT JOIN source_facility ON LOWER(source_facility."FACGROUP") = LOWER(source_facility_group.group)
+LEFT JOIN facility_domain ON LOWER(facility_domain.name) = LOWER(source_facility."FACDOMAIN");
+
+INSERT INTO facility_subgroup (name, description, facility_group_id)
+SELECT DISTINCT
+    source_facility_subgroup.subgroup as name,
+    source_facility_subgroup.description as description,
+    facility_group.id as facility_group_id
+FROM source_facility_subgroup
+RIGHT JOIN source_facility ON LOWER(source_facility."FACSUBGRP") = LOWER(source_facility_subgroup.subgroup)
+LEFT JOIN facility_group ON LOWER(facility_group.name) = LOWER(source_facility."FACGROUP");
+
+INSERT INTO facility_type (name, facility_subgroup_id)
+SELECT DISTINCT
+    source_facility."FACTYPE" as name,
+    facility_subgroup.id as facility_subgroup_id
+FROM source_facility
+LEFT JOIN facility_subgroup ON LOWER(source_facility."FACSUBGRP") = LOWER(facility_subgroup.name);
+    
 COPY facility_operator TO '/var/lib/postgresql/data/facility_operator.csv';
+COPY facility_domain TO '/var/lib/postgresql/data/facility_domain.csv';
+COPY facility_group TO '/var/lib/postgresql/data/facility_group.csv';
+COPY facility_subgroup TO '/var/lib/postgresql/data/facility_subgroup.csv';
+COPY facility_type TO '/var/lib/postgresql/data/facility_type.csv';


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-data-flow/issues/144

The purpose of this PR is to update the `facility_domain`, `facility_group`, `facility_subgroup` and `facility_type` tables in zoning-api with facilities data. 

How to test:
1. `BUILD=facilities npm run flow` and `BUILD=all npm run flow`. Both should populate/update the above four tables in zoning-api. 
2. Check that the first three tables' contents match the [source data](https://github.com/NYCPlanning/ae-data-flow/tree/main/data) they pull from

e.g.
`facility_type` table in zoning-api **before** running `BUILD=facilities npm run flow`:
<img width="1222" height="229" alt="image" src="https://github.com/user-attachments/assets/a5563499-b251-45f7-9b68-b95670eb4117" />

`facility_type` table in zoning-api **after** running `BUILD=facilities npm run flow`:
<img width="1222" height="229" alt="image" src="https://github.com/user-attachments/assets/8609216c-0deb-46e3-a122-3aa653a45f3e" />



